### PR TITLE
Merge GUI changes and other stuff

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,3 +94,6 @@ buildflags = ["--release"]
 
 [package.metadata.rpm.targets]
 switcheroo = { path = "/usr/bin/switcheroo" }
+
+[profile.release]
+strip = "symbols"

--- a/src/favorites.rs
+++ b/src/favorites.rs
@@ -18,7 +18,7 @@ impl Favorites {
             None => bail!("failed to load data_dir"),
         };
 
-        let favorites = data_dir.join(data_dir.join("favorites"));
+        let favorites = data_dir.join(data_dir.join("switcheroo/favorites"));
 
         if !favorites.is_dir() {
             fs::create_dir_all(&favorites)?;

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -321,17 +321,19 @@ impl PayloadData {
 impl eframe::App for MyApp{
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         egui::TopBottomPanel::top("top_panel").show(ctx, |ui| {
-            // Title
-            ui.label(RichText::new("Switcheroo").size(30.0).strong());
-            
-            /*
             ui.horizontal(|ui| {
+                // Title
+                ui.label(RichText::new("Switcheroo").size(24.0).strong());
+
+                ui.separator();
                 egui::widgets::global_dark_light_mode_switch(ui);
+
+                /*
                 ui.separator();
                 ui.selectable_value(&mut self.tab, Tab::Main,"Main");
                 ui.selectable_value(&mut self.tab, Tab::PayloadManager,"Payload Manager");
+                */
             })
-            */
         });
 
         /*


### PR DESCRIPTION
### Changes:
- Slight UI overhaul. (Still imperfect, will test around with new layouts)
- Most buttons are now very cool icons! 🥳 (Need to find fitting icons for loading and removing favorites)
- The aforementioned buttons have tooltips (hover text)
- Added favorites feature to GUI.
- Added reset button, allows for injecting multiple times without app restart.
- Added darkmode toggle and made darkmode the default. (Maybe autodetect dark/light theme from OS?)
- Symbols are now stripped on the release profile by default, small binary sizes are cool. 😎 

### Important notes:
- Data directory is changed from `<data_dir>/favorites` to `<data_dir>/switcheroo/favorites/` (Makes more sense, atleast on my linux system, don't know how the structure on windows and MacOS is.
- There is some commented out code from my first attempt on the payload manager (which failed lol)